### PR TITLE
Set asset source to REF.EXT

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -482,7 +482,7 @@ function App() {
     {
       id: "asset-1",
       name: "Euler Formula",
-      ref: "euler-formula.png",
+      ref: "euler-formula",
       kind: "image",
       isFile: true,
       url: demoImageDataUrl("Euler Formula", "#0e639c"),
@@ -492,7 +492,7 @@ function App() {
     {
       id: "asset-2",
       name: "Markdown Logo",
-      ref: "markdown-logo.svg",
+      ref: "markdown-logo",
       kind: "image",
       isFile: true,
       url: demoImageDataUrl("Markdown Logo", "#0f766e"),
@@ -502,7 +502,7 @@ function App() {
     {
       id: "asset-3",
       name: "PreTeXt Logo",
-      ref: "pretext-logo.png",
+      ref: "pretext-logo",
       kind: "image",
       isFile: true,
       url: demoImageDataUrl("PreTeXt Logo", "#7c3aed"),

--- a/src/assetTransforms.ts
+++ b/src/assetTransforms.ts
@@ -12,15 +12,48 @@ import type { Asset, AssetKind } from "./types/editor";
 /** Produces the PreTeXt markup for one resolved asset. */
 type AssetTransform = (asset: Asset, ref: string, width?: string) => string;
 
+/** Maps image MIME types to a file extension, used when neither `fileRef` nor `url` carries one. */
+const EXTENSION_BY_CONTENT_TYPE: Record<string, string> = {
+  "image/png": "png",
+  "image/jpeg": "jpg",
+  "image/gif": "gif",
+  "image/svg+xml": "svg",
+  "image/webp": "webp",
+  "image/bmp": "bmp",
+  "image/tiff": "tiff",
+};
+
+/** Pulls a bare extension (no dot) off the path portion of a filename or URL. */
+function extensionOf(value: string): string | undefined {
+  const path = value.split(/[?#]/)[0];
+  return /\.([a-zA-Z0-9]+)$/.exec(path)?.[1];
+}
+
+/**
+ * The file extension for a file-backed image asset, preferring whatever
+ * extension is already present on `fileRef`/`url` and falling back to a
+ * guess from `contentType`.
+ */
+function assetExtension(asset: Asset): string | undefined {
+  return (
+    (asset.fileRef && extensionOf(asset.fileRef)) ||
+    (asset.url && extensionOf(asset.url)) ||
+    (asset.contentType && EXTENSION_BY_CONTENT_TYPE[asset.contentType])
+  );
+}
+
 /**
  * `<image>` markup for an image asset.
  *
- * File-based assets (`isFile`) get a `source` attribute written from
- * `asset.fileRef` (a bare external-asset filename understood by the build
- * server), falling back to `asset.url` when `fileRef` is absent for
- * backwards compatibility. Non-file assets carry no `source` attribute at
- * all; they're defined entirely by their authored `source` content (e.g. a
- * hand-written `<asymptote>`/`<latex-image>` body).
+ * File-based assets (`isFile`) get a `source` attribute built from the
+ * placeholder's own `ref` plus a file extension — e.g. `<plus:image
+ * ref="euler-painting"/>` with a PNG upload emits `source="euler-painting.png"`.
+ * The extension is read off `asset.fileRef`/`asset.url` when one is present
+ * there, or guessed from `asset.contentType` otherwise; the asset's
+ * server-assigned `fileRef`/`url` value itself (e.g. a UUID-based storage
+ * key) is never written into the document. Non-file assets carry no
+ * `source` attribute at all; they're defined entirely by their authored
+ * `source` content (e.g. a hand-written `<asymptote>`/`<latex-image>` body).
  *
  * `asset.source` is the user-authored inner XML (`<shortdescription>`,
  * `<description>`, etc.) and is inserted verbatim as the element's children.
@@ -34,8 +67,9 @@ function transformImageAsset(asset: Asset, ref: string, width?: string): string 
   if (asset.isFile && !asset.fileRef && !asset.url) {
     return `<!-- image asset "${ref}" is marked as file-based but has no fileRef or url -->`;
   }
+  const ext = asset.isFile ? assetExtension(asset) : undefined;
   const sourceAttr = asset.isFile
-    ? ` source="${escapeAttribute(asset.fileRef ?? asset.url!)}"`
+    ? ` source="${escapeAttribute(ext ? `${ref}.${ext}` : ref)}"`
     : "";
   const widthAttr = width ? ` width="${escapeAttribute(width)}"` : "";
   const inner = asset.source?.trim();

--- a/src/assetView.ts
+++ b/src/assetView.ts
@@ -55,7 +55,7 @@ export function buildProjectAssetView(
 
   // 1. Document references, in document order, deduplicated across divisions.
   for (const division of divisions ?? []) {
-    for (const { kind, ref } of parseAssetRefs(division.content)) {
+    for (const { kind, ref } of parseAssetRefs(division.content, division.sourceFormat)) {
       const key = `${kind}:${ref}`;
       if (seen.has(key)) continue;
       seen.add(key);

--- a/src/components/Editors.tsx
+++ b/src/components/Editors.tsx
@@ -671,7 +671,7 @@ const EditorsInner = (props: EditorsInnerProps) => {
     // Auto-create Division records for any new <plus:TYPE ref="id"/> placeholders
     // that appeared in the edited content but don't yet have a matching division.
     const existingIds = new Set(divisions.map((d) => d.xmlId));
-    for (const { xmlId, type } of parseDivisionRefsWithTypes(wrapped)) {
+    for (const { xmlId, type } of parseDivisionRefsWithTypes(wrapped, activeDivisionFormat)) {
       if (!existingIds.has(xmlId)) {
         applyDivisionAdd(createDivisionWithId(xmlId, type, activeDivisionFormat));
         existingIds.add(xmlId); // prevent duplicates within the same edit

--- a/src/sectionUtils.ts
+++ b/src/sectionUtils.ts
@@ -1526,21 +1526,104 @@ function divisionRefSource(refValue: string | null): string {
 }
 
 /**
+ * Return the regex source for a division-ref placeholder written in the ONE
+ * syntax that a division of `format` actually uses:
+ *   - `pretext`  → `<plus:section ref="x"/>`
+ *   - `markdown` → `::section{ref="x"}`
+ *   - `latex`    → `\plus{section}{x}`
+ *
+ * Unlike {@link divisionRefSource}, which matches all three at once, this
+ * restricts scanning to the parent's own format. A `::section{ref="x"}` typed
+ * into a PreTeXt division (e.g. as literal example text, or by a Markdown
+ * author pasting into the wrong pane) is then NOT mistaken for a real child
+ * include — the false match that was producing spurious blank sections.
+ */
+function divisionRefSourceForFormat(
+  format: SourceFormat,
+  refValue: string | null,
+): string {
+  switch (format) {
+    case "pretext":
+      return xmlDivisionRefSource(refValue);
+    case "markdown":
+      return markdownDivisionRefSource(refValue);
+    case "latex":
+      return latexDivisionRefSource(refValue);
+  }
+}
+
+/**
+ * Regex sources matching *verbatim* spans in each source format — regions whose
+ * text is rendered literally and must never be scanned for include placeholders.
+ * An include shown as documentation inside a Markdown code fence
+ * (```` ```\n::section{ref="x"}\n``` ````) or a PreTeXt `<pre>` is an example,
+ * not a real child, so it is blanked out before ref-scanning (see
+ * {@link blankVerbatim}).
+ *
+ * Each entry is an un-anchored source with NO capturing groups (so the
+ * alternatives can be safely `|`-joined). Ordering matters: list block-level
+ * spans (fences, environments) before inline spans so the larger region is
+ * consumed first.
+ */
+const VERBATIM_SOURCES: Record<SourceFormat, string[]> = {
+  // TODO(learning): decide which PreTeXt elements hold verbatim text — see the
+  // request in the assistant's message. Leaving this empty is safe: the
+  // format guard above already stops cross-format false matches; these entries
+  // additionally suppress an include written literally inside a PreTeXt code
+  // sample. Starter examples (verify against the PreTeXt schema before adding):
+  //   "<pre>[\\s\\S]*?</pre>",
+  //   "<c>[\\s\\S]*?</c>",
+  //   "<cd>[\\s\\S]*?</cd>",
+  //   "<program\\b[\\s\\S]*?</program>",
+  pretext: [],
+  markdown: [
+    "```[\\s\\S]*?```", // fenced code block (backticks)
+    "~~~[\\s\\S]*?~~~", // fenced code block (tildes)
+    "`[^`\\n]*`", // inline code span
+  ],
+  latex: [
+    "\\\\begin\\{verbatim\\}[\\s\\S]*?\\\\end\\{verbatim\\}",
+    "\\\\begin\\{lstlisting\\}[\\s\\S]*?\\\\end\\{lstlisting\\}",
+    "\\\\verb\\*?\\|[^|\\n]*\\|", // \verb|...| (pipe delimiter, the common case)
+  ],
+};
+
+/**
+ * Replace every verbatim span (per {@link VERBATIM_SOURCES} for `sourceFormat`)
+ * with equal-length whitespace, preserving newlines. Blanking rather than
+ * deleting keeps character offsets and document order intact for the caller's
+ * subsequent ref scan, and guarantees no placeholder can straddle a blanked
+ * boundary.
+ */
+function blankVerbatim(content: string, sourceFormat: SourceFormat): string {
+  const sources = VERBATIM_SOURCES[sourceFormat];
+  if (sources.length === 0) return content;
+  const re = new RegExp(sources.join("|"), "g");
+  return content.replace(re, (match) => match.replace(/[^\n]/g, " "));
+}
+
+/**
  * Return the ordered list of `xmlId` values referenced by
  * `<plus:* ref="..."/>` placeholders found in `content`.
  *
  * Only direct children are returned — the function does not recurse.
  * Call it for each division in the pool to build the full tree.
+ *
+ * `sourceFormat` is the parent division's format: only that format's include
+ * syntax is scanned, and its verbatim spans are blanked first, so example
+ * placeholders in code samples don't become phantom children.
  */
-export function parseDivisionRefs(content: string): string[] {
+export function parseDivisionRefs(
+  content: string,
+  sourceFormat: SourceFormat,
+): string[] {
   const refs: string[] = [];
-  const re = new RegExp(divisionRefSource(null), "g");
+  const re = new RegExp(divisionRefSourceForFormat(sourceFormat, null), "g");
+  const scanned = blankVerbatim(content, sourceFormat);
   let m: RegExpExecArray | null;
-  while ((m = re.exec(content)) !== null) {
-    // Group 1 = XML form (`<plus:… ref="x"/>`), group 2 = Markdown form
-    // (`::…{ref="x"}`), group 3 = LaTeX form (`\plus{…}{x}`); exactly one
-    // matches per iteration.
-    refs.push(m[1] ?? m[2] ?? m[3]);
+  while ((m = re.exec(scanned)) !== null) {
+    // The per-format source has a single capture group: the ref value.
+    refs.push(m[1]);
   }
   return refs;
 }
@@ -1557,22 +1640,24 @@ export function parseDivisionRefs(content: string): string[] {
  */
 export function parseDivisionRefsWithTypes(
   content: string,
+  sourceFormat: SourceFormat,
 ): { xmlId: string; type: DivisionType }[] {
   const refs: { xmlId: string; type: DivisionType }[] = [];
-  const tag = `(?:${DIVISION_REF_TAG_ALTERNATION})`;
-  // Three alternatives: the PreTeXt form captures tag/ref in groups 1–2, the
-  // Markdown leaf-directive form (`::section{ref="x"}`) in groups 3–4, and the
-  // LaTeX macro form (`\plus{section}{x}`) in groups 5–6.
-  const re = new RegExp(
-    `<plus:(${DIVISION_REF_TAG_ALTERNATION})\\s[^>]*ref="([^"]+)"[^>]*?(?:/>|>\\s*</plus:${tag}>)` +
-      `|::(${DIVISION_REF_TAG_ALTERNATION})(?:\\[[^\\]]*\\])?\\{[^}]*ref="([^"]+)"[^}]*\\}` +
-      `|\\\\plus\\{(${DIVISION_REF_TAG_ALTERNATION})\\}\\{([^}]+)\\}`,
-    "g",
-  );
+  const tags = DIVISION_REF_TAG_ALTERNATION;
+  const closeTag = `(?:${tags})`;
+  // One alternative per format, each capturing tag in group 1 and ref in
+  // group 2, so only the parent's own include syntax is recognised.
+  const source: Record<SourceFormat, string> = {
+    pretext: `<plus:(${tags})\\s[^>]*ref="([^"]+)"[^>]*?(?:/>|>\\s*</plus:${closeTag}>)`,
+    markdown: `::(${tags})(?:\\[[^\\]]*\\])?\\{[^}]*ref="([^"]+)"[^}]*\\}`,
+    latex: `\\\\plus\\{(${tags})\\}\\{([^}]+)\\}`,
+  };
+  const re = new RegExp(source[sourceFormat], "g");
+  const scanned = blankVerbatim(content, sourceFormat);
   let m: RegExpExecArray | null;
-  while ((m = re.exec(content)) !== null) {
-    const tagName = m[1] ?? m[3] ?? m[5];
-    const xmlId = m[2] ?? m[4] ?? m[6];
+  while ((m = re.exec(scanned)) !== null) {
+    const tagName = m[1];
+    const xmlId = m[2];
     const type: DivisionType = tagName === "division" ? "section" : (tagName as DivisionType);
     refs.push({ type, xmlId });
   }
@@ -1602,17 +1687,26 @@ export interface AssetRef {
  * disjoint tag set (`image`/`doenet`) so the two kinds of include are never
  * conflated.
  */
-export function parseAssetRefs(content: string): AssetRef[] {
+export function parseAssetRefs(
+  content: string,
+  sourceFormat: SourceFormat,
+): AssetRef[] {
   const refs: AssetRef[] = [];
-  // XML form captures kind/ref in groups 1–2, the Markdown form in groups 3–4,
-  // and the LaTeX form in groups 5–6.
-  const re =
-    /<plus:(image|doenet)\b[^>]*\bref="([^"]+)"|::(image|doenet)(?:\[[^\]]*\])?\{[^}]*\bref="([^"]+)"[^}]*\}|\\plus\{(image|doenet)\}\{([^}]+)\}/g;
+  // One alternative per format, each capturing kind in group 1 and ref in
+  // group 2, so only the division's own asset-include syntax is recognised
+  // and example placeholders in verbatim spans are ignored.
+  const source: Record<SourceFormat, string> = {
+    pretext: `<plus:(image|doenet)\\b[^>]*\\bref="([^"]+)"`,
+    markdown: `::(image|doenet)(?:\\[[^\\]]*\\])?\\{[^}]*\\bref="([^"]+)"[^}]*\\}`,
+    latex: `\\\\plus\\{(image|doenet)\\}\\{([^}]+)\\}`,
+  };
+  const re = new RegExp(source[sourceFormat], "g");
+  const scanned = blankVerbatim(content, sourceFormat);
   let m: RegExpExecArray | null;
-  while ((m = re.exec(content)) !== null) {
+  while ((m = re.exec(scanned)) !== null) {
     refs.push({
-      kind: (m[1] ?? m[3] ?? m[5]) as AssetRef["kind"],
-      ref: m[2] ?? m[4] ?? m[6],
+      kind: m[1] as AssetRef["kind"],
+      ref: m[2],
     });
   }
   return refs;
@@ -1921,7 +2015,7 @@ function collectReachable(divisions: Division[], rootXmlId: string): Set<string>
     seen.add(id);
     const div = divisions.find((d) => d.xmlId === id);
     if (div) {
-      for (const ref of parseDivisionRefs(div.content)) {
+      for (const ref of parseDivisionRefs(div.content, div.sourceFormat)) {
         queue.push(ref);
       }
     }
@@ -1972,7 +2066,7 @@ export function buildDivisionTree(
   const walk = (parentXmlId: string, depth: number) => {
     const parent = divisions.find((d) => d.xmlId === parentXmlId);
     if (!parent) return;
-    for (const ref of parseDivisionRefs(parent.content)) {
+    for (const ref of parseDivisionRefs(parent.content, parent.sourceFormat)) {
       if (visited.has(ref)) continue;
       const div = divisions.find((d) => d.xmlId === ref);
       if (!div) continue;
@@ -1999,7 +2093,7 @@ export function getOrphanRoots(
   const orphanIds = new Set(orphans.map((d) => d.xmlId));
   const referenced = new Set<string>();
   for (const o of orphans) {
-    for (const ref of parseDivisionRefs(o.content)) {
+    for (const ref of parseDivisionRefs(o.content, o.sourceFormat)) {
       if (orphanIds.has(ref)) referenced.add(ref);
     }
   }

--- a/src/types/editor.ts
+++ b/src/types/editor.ts
@@ -28,28 +28,29 @@ export interface Asset {
   /**
    * Whether this asset is backed by an uploaded/fetched file rather than
    * being defined purely by `source`. File-based image assets emit a
-   * `source` attribute on the generated `<image>` element (from
-   * {@link fileRef}, falling back to {@link url}); non-file image assets
-   * carry no `source` attribute and rely entirely on their authored
+   * `source` attribute on the generated `<image>` element built from this
+   * asset's {@link ref} plus a file extension (e.g. `ref="euler-painting"`
+   * with a PNG upload emits `source="euler-painting.png"`); non-file image
+   * assets carry no `source` attribute and rely entirely on their authored
    * `source` content.
    */
   isFile?: boolean;
   /**
-   * Publicly accessible URL used **only** as the asset-manager thumbnail
-   * (`<img src={url}>`). It is no longer the value written to the `<image>`
-   * `source` attribute — use {@link fileRef} for that. It remains the
-   * `source` fallback when `fileRef` is absent, for backwards compatibility.
+   * Publicly accessible URL used as the asset-manager thumbnail
+   * (`<img src={url}>`). Its filename extension (if any) is also used, as a
+   * fallback after {@link fileRef}, to determine the extension appended to
+   * `ref` for the generated `<image source="...">` attribute. The URL itself
+   * (e.g. a UUID-based storage key) is never written into the document.
    */
   url?: string;
   /**
-   * The exact string emitted as the `source` attribute of the generated
-   * `<image>` element for a file-backed asset — typically a bare external
-   * filename like `"euler-painting.png"`. The PreTeXt build server treats
-   * `<image source="X">` as an external-asset filename and prepends
-   * `external/` itself, so this must be a bare filename, not a URL.
+   * The server-assigned storage filename for a file-backed asset (e.g. a
+   * UUID-based key). Its extension, if present, is used to build the
+   * `source` attribute of the generated `<image>` element as
+   * `"{ref}.{extension}"` — the rest of this value (e.g. the UUID itself)
+   * is never written into the document.
    *
-   * Only meaningful when {@link isFile} is true. When absent, the emit sites
-   * fall back to {@link url} so existing hosts keep working unchanged.
+   * Only meaningful when {@link isFile} is true.
    */
   fileRef?: string;
   /** Mime type for the asset, if applicable.  Used for hints only. */


### PR DESCRIPTION
Converts `<plus:image ref="REF_ID"/>` to `<image source="REF_ID.EXT"/>` rather than `<image source="UUID"/>`. Allows us to produce better PreTeXt source for humans, and serve up urls at `external/REF_ID.EXT` that match the resource filetype.

Requires an update to the Rails app to serve up these resources appropriately.